### PR TITLE
respond to deserialization errors with json

### DIFF
--- a/lib/MetaCPAN/Server/Action/Deserialize.pm
+++ b/lib/MetaCPAN/Server/Action/Deserialize.pm
@@ -1,0 +1,28 @@
+package MetaCPAN::Server::Action::Deserialize;
+use Moose;
+extends 'Catalyst::Action::Deserialize';
+use Cpanel::JSON::XS qw(encode_json);
+
+around serialize_bad_request => sub {
+    my $orig = shift;
+    my $self = shift;
+    my ( $c, $content_type, $error ) = @_;
+
+    $c->res->status(400);
+
+    my $full_error
+        = "Content-Type $content_type had a problem with your request.\n$error";
+    $full_error =~ s{ at .*? line \d+\.\n\z}{};
+
+    $c->stash(
+        {
+            rest => {
+                error => $full_error,
+            },
+        }
+    );
+
+    return undef;
+};
+
+1;

--- a/lib/MetaCPAN/Server/Controller.pm
+++ b/lib/MetaCPAN/Server/Controller.pm
@@ -93,13 +93,13 @@ sub get : Path('') : Args(1) {
         ['The requested field(s) could not be found'] );
 }
 
-sub all : Path('') : Args(0) : ActionClass('Deserialize') {
+sub all : Path('') : Args(0) : ActionClass('~Deserialize') {
     my ( $self, $c ) = @_;
     $c->req->params->{q} ||= '*' unless ( $c->req->data );
     $c->forward('search');
 }
 
-sub search : Path('_search') : ActionClass('Deserialize') {
+sub search : Path('_search') : ActionClass('~Deserialize') {
     my ( $self, $c ) = @_;
     my $req = $c->req;
 
@@ -129,7 +129,7 @@ sub search : Path('_search') : ActionClass('Deserialize') {
     } or do { $self->internal_error( $c, $@ ) };
 }
 
-sub join : ActionClass('Deserialize') {
+sub join : ActionClass('~Deserialize') {
     my ( $self, $c ) = @_;
     my $joins     = $self->relationships;
     my @req_joins = $c->req->param('join');

--- a/t/server/controller/bad_content.t
+++ b/t/server/controller/bad_content.t
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Cpanel::JSON::XS ();
+use MetaCPAN::Server ();
+use MetaCPAN::TestHelpers;
+use Plack::Test;
+use Test::More;
+use Ref::Util qw( is_arrayref is_hashref );
+
+my $app  = MetaCPAN::Server->new->to_app();
+my $test = Plack::Test->create($app);
+
+subtest "broken body content" => sub {
+    my $source = q[
+        { "query : { } }
+    ];
+
+    for my $type (qw( release file )) {
+        my $url     = "/$type/_search";
+        my $request = HTTP::Request->new( 'POST', $url, [], $source );
+
+        subtest "check with '$type' controller" => sub {
+            my $res = $test->request($request);
+
+            ok( $res, "GET $url" );
+            is( $res->code, 400, "code 400" );
+            is(
+                $res->header('content-type'),
+                'application/json; charset=utf-8',
+                'Content-type'
+            );
+            my $content
+                = eval { Cpanel::JSON::XS::decode_json( $res->content ) };
+            ok( is_hashref($content), 'content is a JSON object' );
+            ok $content->{error}, 'content includes includes error';
+        };
+    }
+};
+
+done_testing;


### PR DESCRIPTION
If there is an error while deserializing, it is nicer to respond with a
JSON response, rather than plain text. Use a custom Deserialize action
class, which puts the error into the stash where either the Serialize
action class or the JSON view expects. And then skip the rest of the
request.